### PR TITLE
Used Arc::clone rather then just using the .clone for the port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 mod animation;
 mod proxy;
 use crate::proxy::proxy;
-use actix_web::{web, App, HttpServer};
+use actix_web::{App, HttpServer, web};
 use animation::{show_pulsing, start_spinner};
 use args::VoxlanArgs;
 use qr2term::print_qr;
@@ -42,7 +42,9 @@ async fn main() -> std::io::Result<()> {
                         backend_port.store(number, atomic::Ordering::Relaxed);
                         *link.lock().unwrap() = format!("http://{}:8081", local_ip);
                     } else {
-                        println!("The port is not active check the server again or list the port and try again");
+                        println!(
+                            "The port is not active check the server again or list the port and try again"
+                        );
                         return Ok(());
                     }
                 }
@@ -90,7 +92,9 @@ async fn main() -> std::io::Result<()> {
                         client(number, path).await.unwrap();
                         return Ok(());
                     } else {
-                        println!("The port is not active check the server again or list the port and try again");
+                        println!(
+                            "The port is not active check the server again or list the port and try again"
+                        );
                         return Ok(());
                     };
                 }
@@ -153,6 +157,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(web::Data::new(client.clone()))
             .app_data(web::Data::new(backend_port.clone()))
+            .app_data(web::Data::new(Arc::clone(&backend_port)))
             .default_service(web::route().to(proxy))
     })
     .bind("0.0.0.0:8081")?

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,10 +1,10 @@
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, Ordering};
 
 use crate::Client;
-use actix_web::web;
 use actix_web::HttpRequest;
 use actix_web::HttpResponse;
+use actix_web::web;
 
 pub async fn proxy(
     req: HttpRequest,


### PR DESCRIPTION
Here we are transferring the value of the port to multiple threads mutably and previously we used .clone to send it to the proxy function but now we are using the Arc::clone and the AtomicU16 stays the same because we are getting little bit more performance here comparatively with the Mutex and it is more safe and will not create any dead locks. 